### PR TITLE
Provide scripted access to wizard internals

### DIFF
--- a/ChangeTracker.py
+++ b/ChangeTracker.py
@@ -93,10 +93,10 @@ class ChangeTrackerWidget:
     allSteps.append( self.reportROIStep )
 
     # Add transition for the first step which let's the user choose between simple and advanced mode
-    self.workflow.addTransition( self.selectScansStep, defineROIStep )
-    self.workflow.addTransition( self.defineROIStep, segmentROIStep )
-    self.workflow.addTransition( self.segmentROIStep, analyzeROIStep )
-    self.workflow.addTransition( self.analyzeROIStep, reportROIStep )
+    self.workflow.addTransition( self.selectScansStep, self.defineROIStep )
+    self.workflow.addTransition( self.defineROIStep, self.segmentROIStep )
+    self.workflow.addTransition( self.segmentROIStep, self.analyzeROIStep )
+    self.workflow.addTransition( self.analyzeROIStep, self.reportROIStep )
 
     nNodes = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLScriptedModuleNode')
 


### PR DESCRIPTION
For the RSNA testing script I need to get at the steps.

See:

http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=21126

Can you look at this and merge it and then update the SuperBuild/External_ChangeTracker.cmake file to point to the new version?  This will allow the test to run.

Thanks!
-Steve

http://na-mic.org/Bug/view.php?id=2517
